### PR TITLE
#8 #11 リンクミスのリソースの削除と単数と複数の命名の修正

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 		948152022971876C00C4D3D9 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				94E4BA992972CD5D000780DA /* Constants */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945EC244DC5EB0012785A /* Info.plist */,
 			);
@@ -229,13 +228,6 @@
 				94E4BA932972BCBF000780DA /* Repository.swift */,
 			);
 			path = Entities;
-			sourceTree = "<group>";
-		};
-		94E4BA992972CD5D000780DA /* Constants */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Constants;
 			sourceTree = "<group>";
 		};
 		BFD945D2244DC5E80012785A = {

--- a/iOSEngineerCodeCheck/Sources/Controllers/Home/HomeViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Controllers/Home/HomeViewController.swift
@@ -15,7 +15,8 @@ class HomeViewController: UIViewController {
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var searchResultTableView: UITableView!
     
-    var repositories: RepositoryModel?
+    // MARK: - repositoryModelではなく、他の命名もいいかも！
+    var repositoryModel: RepositoryModel?
     var task: URLSessionTask?
     private(set) var presenter: HomeViewPresenter!
     private let loadingView: LoadingView = {
@@ -79,7 +80,7 @@ class HomeViewController: UIViewController {
         ])
     }
     
-    func showErrorAlert(title: String, message: String) -> UIAlertController {
+    func showsErrorAlert(title: String, message: String) -> UIAlertController {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let check = UIAlertAction(title: "確認", style: .default) { _ in
             self.dismiss(animated: true)
@@ -91,12 +92,12 @@ class HomeViewController: UIViewController {
 
 extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return repositories?.items.count ?? 0
+        return repositoryModel?.items.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if let cell = tableView.dequeueReusableCell(withIdentifier: "HomeTableViewCell", for: indexPath) as? HomeTableViewCell {
-            if let repository = repositories?.items[indexPath.row] {
+            if let repository = repositoryModel?.items[indexPath.row] {
                 cell.configure(repository: repository)
             }
             return cell
@@ -106,7 +107,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let repository = repositories?.items[indexPath.row] {
+        if let repository = repositoryModel?.items[indexPath.row] {
             let resultDetailViewController = ResultDetailViewController.instantiate(with: repository)
             if let imageURL = repository.owner.avatarURL {
                 resultDetailViewController.presenter.loadImage(from: imageURL)
@@ -164,8 +165,9 @@ extension HomeViewController {
 
 // MARK: - Searchをすると、アップデートされるHomeView
 extension HomeViewController: HomeView {
-    func shouldShowResult(with repository: RepositoryModel) {
-        self.repositories = repository
+    func shouldShowResult(with repositoryModel: RepositoryModel) {
+        // ここで、単数と複数の等価的な扱いになっていたんで、修正
+        self.repositoryModel = repositoryModel
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
             self.searchResultTableView.reloadData()
@@ -176,7 +178,7 @@ extension HomeViewController: HomeView {
         print("Status Code: \(response.statusCode)")
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
-            self.present(self.showErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
+            self.present(self.showsErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
         }
     }
     
@@ -185,7 +187,7 @@ extension HomeViewController: HomeView {
         print("Network Error: \(error.localizedDescription)")
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
-            self.present(self.showErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
+            self.present(self.showsErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
         }
     }
     
@@ -193,7 +195,7 @@ extension HomeViewController: HomeView {
         print("Parsing Error: fail to show result")
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
-            self.present(self.showErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
+            self.present(self.showsErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
         }
     }
 }

--- a/iOSEngineerCodeCheck/Sources/Controllers/ResultDetail/ResultDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Controllers/ResultDetail/ResultDetailViewController.swift
@@ -20,7 +20,6 @@ class ResultDetailViewController: UIViewController {
     @IBOutlet weak var repositoryForksCountLabel: UILabel!
     @IBOutlet weak var repositoryIssuesCountLabel: UILabel!
     
-    var repositoryData: Repository?
     private(set) var presenter: ResultDetailViewPresenter!
     private let loadingView: LoadingView = {
         let view = LoadingView()
@@ -55,7 +54,7 @@ class ResultDetailViewController: UIViewController {
         ])
     }
     
-    func showErrorAlert(title: String, message: String) -> UIAlertController {
+    func showsErrorAlert(title: String, message: String) -> UIAlertController {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let check = UIAlertAction(title: "確認", style: .default) { _ in
             self.dismiss(animated: true)
@@ -118,7 +117,7 @@ extension ResultDetailViewController: ResultDetailView {
         print("Network Error: \(error.localizedDescription)")
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
-            self.present(self.showErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
+            self.present(self.showsErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
         }
     }
     
@@ -126,7 +125,7 @@ extension ResultDetailViewController: ResultDetailView {
         // Imageを正しくfetchするのに失敗
         DispatchQueue.main.async {
             self.loadingView.isLoading = false
-            self.present(self.showErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
+            self.present(self.showsErrorAlert(title: errorType.alertTitle, message: errorType.alertMessage), animated: true)
         }
     }
 }


### PR DESCRIPTION
#5 
- [ ] #8 
- [ ] #11 
resolved: #8 #11 

##やったこと
- リンクミスされているConstantsフォルダーを削除した。今後、言語ごとのcolorの表示を実装するとき、ふたたび再構築する予定。完成品には、リンクミスやコミットアウトは残さないのが正しい開発である。
- HomeViewControllerで実装したshouldShowResult プロトコルのパラメータの命名がrepositoryという単数の表現にしたのに、それを受け取るHomeViewControllerの変数名は、repositoriesとなっていたのが問題であった。そのため、repositoriesではなくrepositoryModelに名前を変えた。
