### PR TITLE
#19 textが切れてしまう現象を解決

### DIFF
--- a/iOSEngineerCodeCheck/Sources/Controllers/ResultDetail/ResultDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Sources/Controllers/ResultDetail/ResultDetailViewController.swift
@@ -13,7 +13,14 @@ import UIKit
 class ResultDetailViewController: UIViewController {
     
     @IBOutlet weak var repositoryImageView: UIImageView!
-    @IBOutlet weak var repositoryTitleLabel: UILabel!
+    @IBOutlet weak var repositoryTitleLabel: UILabel! {
+        didSet {
+            // repository名が長くなると、切れてしまう問題を防ぐため
+            repositoryTitleLabel.adjustsFontSizeToFitWidth = true
+            // font sizeの最小値を設定しないと、無限に縮小されてします。（defaultが0であるため）
+            repositoryTitleLabel.minimumScaleFactor = 0.5
+        }
+    }
     @IBOutlet weak var repositoryLanguageLabel: UILabel!
     @IBOutlet weak var repositoryStarsCountLabel: UILabel!
     @IBOutlet weak var repositoryWatchersCountLabel: UILabel!


### PR DESCRIPTION
#6 の #19 を解決
- [ ] #18 
- [x] #19 
- [x] #20 
resolved: #19  

理由: 
repository名が長くなるとテキストが全部見えていないという問題があったので、解決した。